### PR TITLE
Setup clean

### DIFF
--- a/.companion.rc
+++ b/.companion.rc
@@ -11,7 +11,7 @@ done
 sudo udevadm trigger
 
 if [ ! -f /home/pi/.updating ]; then
-	sudo python $COMPANION_DIR/tools/ping_enumerator.py || true
+	sudo python3 $COMPANION_DIR/tools/ping_enumerator.py || true
 	if [ -d /dev/serial/ping ]; then
 		sudo -H -u pi screen -dm -S pingproxy pingproxy.py --device $(ls -d /dev/serial/ping/Ping1* | head -1)
 		sudo -H -u pi screen -dm -S pingmav python $COMPANION_DIR/tools/ping1d_mavlink_driver.py

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -33,7 +33,6 @@ run_step sudo apt install $APT_OPTIONS \
   gstreamer1.0-plugins-bad \
   gstreamer1.0-plugins-ugly \
   isc-dhcp-server \
-  python3-pip \
   libv4l-dev \
   v4l-utils \
   libkrb5-dev \
@@ -53,7 +52,10 @@ run_step sudo pip install \
   bluerobotics-ping \
   || error "failed pip install dependencies"
 
-run_step sudo pip3 install future || error "failed pip3 install dependencies"
+run_step sudo pip3 install \
+  future \
+  bluerobotics-ping \
+  || error "failed pip3 install dependencies"
 
 # todo adjust so this can be run when the directory already exists
 # clone bluerobotics companion repository

--- a/tools/ping360_bridge_manager.py
+++ b/tools/ping360_bridge_manager.py
@@ -40,7 +40,6 @@ def device_has_screen(device):
     screen_name = screen_name_for_device(device)
     try:
         output = subprocess.check_output(["sudo", "-Au", "pi", "screen", "-ls"], universal_newlines=True)
-        return output.decode()
     except subprocess.CalledProcessError as e:
         if e.returncode == 1:
             output = e.output  # screen v4.2.x always gives exit code of 1 for 'screen -ls'
@@ -66,12 +65,14 @@ def create_device_screen(device, port):
         # Strip newline from output
         target_device = target_device.decode().split('\n')[0]
     except Exception as e:
-        print("Error reading symlink: %s" % e)
+        print("Error reading symlink:", e)
         return False
     path = os.path.dirname(os.path.abspath(__file__))
     screen_name = screen_name_for_device(device)
-    command = "sudo -H -u pi screen -dm -S %s %s/bridges -u 0.0.0.0:%s -p %s:2000000"  # Ignores EOF if it shows in the data in the serial sid
-    command = command % (screen_name, path, port, target_device)
+
+    # Ignores EOF if it shows in the data in the serial sid
+    command = f"sudo -H -u pi screen -dm -S {screen_name} {path}/bridges -u 0.0.0.0:{port} -p {target_device}:2000000"
+
     print("Launching: ", command)
     try:
         subprocess.check_output(command, shell=True)

--- a/tools/ping_enumerator.py
+++ b/tools/ping_enumerator.py
@@ -37,7 +37,8 @@ class PingEnumerator:
         """
 
         try:
-            ping = PingDevice("/dev/serial/by-id/" + dev, 115200)
+            ping = PingDevice()
+            ping.connect_serial("/dev/serial/by-id/" + dev, 115200)
         except Exception as exception:
             print("An exception has occurred: ", exception)
             return None


### PR DESCRIPTION
Fix the relevant pieces of setup code to get ping360 to work on RPi4.

Note that `bluerobotics-ping` is now pip installed for both python 2 and 3 as I wasn't sure if it's required for python 2 for ping1D. If this isn't required then it should be removed from the old `pip` section and left only in the `pip3` section.